### PR TITLE
Fix Order entity constant typo

### DIFF
--- a/src/Getnet/API/Order.php
+++ b/src/Getnet/API/Order.php
@@ -13,7 +13,7 @@ class Order implements \JsonSerializable {
     const PRODUCT_TYPE_DIGITAL_GOODS    = "digital_goods";
     const PRODUCT_TYPE_DIGITAL_PHYSICAL = "digital_physical";
     const PRODUCT_TYPE_GIFT_CARD        = "gift_card";
-    const PRODUCT_TYPE_PHISICAL_GOODS   = "phisical_goods";
+    const PRODUCT_TYPE_PHISICAL_GOODS   = "physical_goods";
     const PRODUCT_TYPE_RENEW_SUBS       = "renew_subs";
     const PRODUCT_TYPE_SHAREWARE        = "shareware";
     const PRODUCT_TYPE_SERVICE          = "service";


### PR DESCRIPTION
Should be physical_goods, not phisical_goods

"product_type" must be one of [cash_carry, digital_content, digital_goods, digital_physical, gift_card, physical_goods, renew_subs, shareware, service]"