### PR TITLE
Fix: Appends Authorization Bearer Header for GET methods to avoid un-…

### DIFF
--- a/src/Getnet/API/Request.php
+++ b/src/Getnet/API/Request.php
@@ -125,7 +125,8 @@ class Request {
             $defaultCurlOptions[CURLOPT_HTTPHEADER][] = 'Authorization: Bearer ' . $credentials->getAuthorizationToken();
             curl_setopt($curl, CURLOPT_POST, 1);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
-            
+        } elseif ($method == self::CURL_TYPE_GET) {
+            $defaultCurlOptions[CURLOPT_HTTPHEADER][] = 'Authorization: Bearer ' . $credentials->getAuthorizationToken();
         } elseif ($method == self::CURL_TYPE_PUT) {
             $defaultCurlOptions[CURLOPT_HTTPHEADER][] = 'Authorization: Bearer ' . $credentials->getAuthorizationToken();
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, self::CURL_TYPE_PUT);


### PR DESCRIPTION
…authorized issues

Ao efetuar requisições GET, o header "Authorization: Bearer <token>" está sendo perdido na chamada do método \Getnet\API\Request#send() e, consequentemente, qualquer retorno da API apresentava erro de autenticação. 

Este pull-request preserva o header mencionado, permitindo utilizar qualquer endpoint que utilize o verbo GET 

Em nossa aplicação laravel em conjunto com getnet-php, tivemos de implementar outros métodos públicos da API da Getnet que utilizam endpoints GET, como por exemplo, obter cartões salvos no Cofre pelo endpoint /v1/cards/