### PR TITLE
Update Getnet.php

### DIFF
--- a/src/Getnet/API/Getnet.php
+++ b/src/Getnet/API/Getnet.php
@@ -264,7 +264,7 @@ class Getnet {
         try {
             $request = new Request($this);
             $response = $request->post($this, "/v1/payments/boleto", $transaction->toJSON());
-            if ($this->debug)
+            if (isset($this->debug))
                 print $transaction->toJSON();
         } catch (\Exception $e) {
 


### PR DESCRIPTION
Ao gerar o Boleto, Acontecia um um erro ao tentar acessar a propriedade debug pois ela não existia. No painel administrativo da GetNet a Resposta vinha como correta, porém ao chegar nesta linha gerava um Exception, por este motivo. se meu pensamento estiver errado por favor volte a alteração da linha 267 para if($this->debug).